### PR TITLE
Adding code folding buttons to both themes (Build 2132)

### DIFF
--- a/Soda Dark.sublime-theme
+++ b/Soda Dark.sublime-theme
@@ -100,6 +100,33 @@
     },
 
 //
+// FOLD BUTTONS
+//
+
+    {
+        "class": "fold_button_control",
+        "layer0.texture": "Theme - Soda/Soda Dark/group-closed.png",
+        "layer0.opacity": 1.0,
+        "layer0.inner_margin": 0,
+        "layer1.texture": "Theme - Soda/Soda Dark/group-closed-pressed.png",
+        "layer1.opacity": 0.0,
+        "layer1.inner_margin": 0,
+        "content_margin": [9, 7, 8, 6]
+    },
+    {
+        "class": "fold_button_control",
+        "attributes": ["hover"],
+        "layer0.opacity": 0.0,
+        "layer1.opacity": 1.0
+    },
+    {
+        "class": "fold_button_control",
+        "attributes": ["expanded"],
+        "layer0.texture": "Theme - Soda/Soda Dark/group-open.png",
+        "layer1.texture": "Theme - Soda/Soda Dark/group-open-pressed.png"
+    },
+
+//
 // STANDARD SCROLLBARS
 //
 

--- a/Soda Light.sublime-theme
+++ b/Soda Light.sublime-theme
@@ -100,6 +100,33 @@
     },
 
 //
+// FOLD BUTTONS
+//
+
+    {
+        "class": "fold_button_control",
+        "layer0.texture": "Theme - Soda/Soda Light/group-closed.png",
+        "layer0.opacity": 1.0,
+        "layer0.inner_margin": 0,
+        "layer1.texture": "Theme - Soda/Soda Light/group-closed-pressed.png",
+        "layer1.opacity": 0.0,
+        "layer1.inner_margin": 0,
+        "content_margin": [9, 7, 8, 6]
+    },
+    {
+        "class": "fold_button_control",
+        "attributes": ["hover"],
+        "layer0.opacity": 0.0,
+        "layer1.opacity": 1.0
+    },
+    {
+        "class": "fold_button_control",
+        "attributes": ["expanded"],
+        "layer0.texture": "Theme - Soda/Soda Light/group-open.png",
+        "layer1.texture": "Theme - Soda/Soda Light/group-open-pressed.png"
+    },
+
+//
 // STANDARD SCROLLBARS
 //
 


### PR DESCRIPTION
Updated both the light and dark themes with code folding buttons, using the group buttons from the side bar.
